### PR TITLE
Alteração no mochawesome, instalação Cypress parallel e rimraf

### DIFF
--- a/.github/workflows/cypress-pipeline-schedule.yml
+++ b/.github/workflows/cypress-pipeline-schedule.yml
@@ -4,7 +4,7 @@ name: Run Basic Tests Schedule
 # Em que momento será executada
 on:
   schedule:
-    - cron: '35 22 * 9 1-5'
+    - cron: '35 22 12 10 1-5'
 
 jobs:
   # O que vai ser feito nessa pipeline

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -8,6 +8,7 @@ module.exports = defineConfig({
   reporter: 'cypress-mochawesome-reporter',
   reporterOptions: {
     charts: true,
+    overwrite: false,
     reportTitle: 'Projeto do curso de Cypress',
     reportPageTitle: 'Projeto do curso de Cypress',
   },
@@ -30,4 +31,4 @@ module.exports = defineConfig({
       return config;
     },
   },
-});
+})

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "cypress:home": "cypress run --spec \"cypress/e2e/features/home_page.feature\"",
+    "cypress:login": "cypress run --spec \"cypress/e2e/features/login.feature\"",
+    "cypress:parallel": "npm run clean-reports && npm-run-all --parallel cypress:login cypress:home",
+    "clean-reports": "rimraf cypress/reports/html"
   },
   "keywords": [],
   "author": "",
@@ -12,10 +16,13 @@
   "dependencies": {
     "@badeball/cypress-cucumber-preprocessor": "^18.0.5",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
-    "cypress": "^13.1.0",
+    "cypress-parallel": "^0.13.0",
     "cypress-real-events": "^1.10.3"
   },
   "devDependencies": {
-    "cypress-mochawesome-reporter": "^3.6.0"
+    "cypress": "^13.3.0",
+    "cypress-mochawesome-reporter": "^3.6.0",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^5.0.5"
   }
 }


### PR DESCRIPTION
Inclusão da linha overwrite = false sobre o mochawesome no arquivo cypress.config.js para quando tiver mais de um relatório no teste, o mochawesome crie um outro arquivo de testes ao invés de substituir

Instalação Cypress parallel para realizar execução de testes em paralelo ao invés de testes sequenciais
Definição de grupos de testes e configuração da linha de comando para executar via terminal no bloco scripts do arquivo package.json
    "cypress:home": "cypress run --spec \"cypress/e2e/features/home_page.feature\"",
    "cypress:login": "cypress run --spec \"cypress/e2e/features/login.feature\"",
    "cypress:parallel": "npm run clean-reports && npm-run-all --parallel cypress:login cypress:home"

Instalação do rimraf para que toda vez que rode os testes, o rimraf apague da pasta de relatórios os relatórios antigos dos testes passados
Definição do caminho da pasta que o rimraf vai apagar os relatórios antigos no arquivo package.json
     "clean-reports": "rimraf cypress/reports/html"